### PR TITLE
Update full_description.txt

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,7 @@
 Litube is an advanced webview wrapper for YouTube.
 
-## Features
-* **Ad-free playback.**
-* **Background & Picture-in-Picture support.**
-* **Built-in video downloader.**
-* **Live stream chat support, etc.**
+<b>Features</b>
+* <b>Ad-free playback</b>
+* <b>Background & Picture-in-Picture support</b>
+* <b>Built-in video downloader</b>
+* <b>Live stream chat support, etc.</b>


### PR DESCRIPTION
I changed the header formatting from Markdown to Simple HTML because IzzyOnDroid supports both equally well, but F-Droid does not support Markdown, displaying Markdown tags as is.

Additionally, in English, when using formatted lists, periods are not used unless the list items are complete sentences.